### PR TITLE
Yangkee -> Yankee

### DIFF
--- a/00_license.md
+++ b/00_license.md
@@ -155,7 +155,7 @@
 | V | Victor
 | W | Whisky
 | X | X-ray
-| Y | Yangkee
+| Y | Yankee
 | Z | Zulu
 
 


### PR DESCRIPTION
Minor adjustment to the phonetic spelling of 'Y'/Yankee

I've tried looking around online for phonetic alphabets which spells 'Y'
as "Yangkee" but to no avail so this might be incorrect 😅

https://en.wikipedia.org/wiki/NATO_phonetic_alphabet#Code_words